### PR TITLE
feat: add get_engines and get_engine requests

### DIFF
--- a/apimoex/__init__.py
+++ b/apimoex/__init__.py
@@ -16,6 +16,8 @@ from apimoex.requests import (
     get_board_dates,
     get_board_history,
     get_board_securities,
+    get_engine,
+    get_engines,
     get_index_tickers,
     get_market_candle_borders,
     get_market_candles,
@@ -36,5 +38,7 @@ __all__ = [
     "get_market_history",
     "get_board_history",
     "get_index_tickers",
+    "get_engines",
+    "get_engine",
     "ISSClient",
 ]

--- a/apimoex/requests.py
+++ b/apimoex/requests.py
@@ -607,7 +607,7 @@ def get_engines(session: requests.Session) -> client.Table:
 
     Например: https://iss.moex.com/iss/engines.json — stock, futures, currency и т.д.
 
-    Описание запроса - https://iss.moex.com/iss/reference/40
+    Описание запроса - https://iss.moex.com/iss/reference/391
 
     :param session:
         Сессия интернет соединения.
@@ -635,7 +635,7 @@ def get_engine(
         ``is_work_day=0`` — выходной/праздник, ``1`` — перенос рабочего дня. Источник
         торгового календаря MOEX (выходные/праздники/переносы).
 
-    Описание запроса - https://iss.moex.com/iss/reference/41
+    Описание запроса - https://iss.moex.com/iss/reference/397
 
     :param session:
         Сессия интернет соединения.

--- a/apimoex/requests.py
+++ b/apimoex/requests.py
@@ -22,6 +22,8 @@ __all__ = [
     "get_market_history",
     "get_board_history",
     "get_index_tickers",
+    "get_engines",
+    "get_engine",
 ]
 
 
@@ -598,3 +600,54 @@ def get_index_tickers(
     query = _make_query(date=date, table=table, columns=columns)
 
     return _get_short_data(session, url, table, query)
+
+
+def get_engines(session: requests.Session) -> client.Table:
+    """Получить перечень доступных торговых систем (движков) MOEX.
+
+    Например: https://iss.moex.com/iss/engines.json — stock, futures, currency и т.д.
+
+    Описание запроса - https://iss.moex.com/iss/reference/40
+
+    :param session:
+        Сессия интернет соединения.
+
+    :return:
+        Список словарей (id, name, title), который напрямую конвертируется в pandas.DataFrame.
+    """
+    url = "https://iss.moex.com/iss/engines.json"
+    table = "engines"
+
+    return _get_short_data(session, url, table)
+
+
+def get_engine(
+    session: requests.Session,
+    engine: str = "stock",
+    table: str = "dailytable",
+) -> client.Table:
+    """Получить описание и режим работы торговой системы (движка).
+
+    Например: https://iss.moex.com/iss/engines/stock.json — содержит три таблицы:
+      * ``engine``     — описание движка (NAME, title, short_title);
+      * ``timetable``  — недельное расписание (week_day, is_work_day, start/stop_time);
+      * ``dailytable`` — календарь исключений по датам (date, is_work_day, start/stop_time):
+        ``is_work_day=0`` — выходной/праздник, ``1`` — перенос рабочего дня. Источник
+        торгового календаря MOEX (выходные/праздники/переносы).
+
+    Описание запроса - https://iss.moex.com/iss/reference/41
+
+    :param session:
+        Сессия интернет соединения.
+    :param engine:
+        Движок - по умолчанию ``stock`` (фондовый рынок).
+    :param table:
+        Какую из таблиц вернуть: ``dailytable`` (по умолчанию, календарь),
+        ``timetable`` (недельное расписание) или ``engine`` (описание).
+
+    :return:
+        Список словарей выбранной таблицы, который напрямую конвертируется в pandas.DataFrame.
+    """
+    url = f"https://iss.moex.com/iss/engines/{engine}.json"
+
+    return _get_short_data(session, url, table)

--- a/tests/test_requests.py
+++ b/tests/test_requests.py
@@ -271,3 +271,41 @@ def test_get_index_tickers(session):
     assert data[15]["ticker"] == "MAGN"
     assert data[25]["till"] == "2023-03-03"
     assert data[35]["tradingsession"] == 3
+
+
+def test_get_engines(session):
+    data = requests.get_engines(session)
+    assert isinstance(data, list)
+    assert len(data) >= 10
+    df = pd.DataFrame(data).set_index("name")
+    assert df.at["stock", "id"] == 1
+    assert df.at["stock", "title"] == "Фондовый рынок и рынок депозитов"
+    assert "futures" in df.index
+
+
+def test_get_engine_dailytable(session):
+    # по умолчанию dailytable — календарь исключений (выходные/праздники/переносы)
+    data = requests.get_engine(session, "stock")
+    assert isinstance(data, list)
+    assert len(data) > 0
+    row = data[0]
+    assert {"date", "is_work_day", "start_time", "stop_time"} <= set(row)
+    df = pd.DataFrame(data).set_index("date")
+    # стабильные исторические записи (новый праздник в таблицу не задним числом)
+    assert df.at["2018-05-09", "is_work_day"] == 0      # перенос/праздник — нерабочий
+    assert df.at["2021-02-20", "is_work_day"] == 1      # суббота-отработка — рабочий
+
+
+def test_get_engine_timetable(session):
+    data = requests.get_engine(session, "stock", "timetable")
+    assert isinstance(data, list)
+    assert len(data) == 7                                # 7 дней недели
+    df = pd.DataFrame(data).set_index("week_day")
+    assert set(df.columns) >= {"is_work_day", "start_time", "stop_time"}
+
+
+def test_get_engine_description(session):
+    data = requests.get_engine(session, "stock", "engine")
+    assert isinstance(data, list)
+    assert len(data) == 1
+    assert data[0]["NAME"] == "stock"


### PR DESCRIPTION
﻿Adds two ISS endpoints missing from the library:

- `get_engines(session)` -> `/iss/engines` - list of trading systems (engines: stock, futures, currency, ...).
- `get_engine(session, engine="stock", table="dailytable")` -> `/iss/engines/[engine]` - engine description plus weekly `timetable` and per-date `dailytable`. The `dailytable` exposes the MOEX trading calendar: `is_work_day=0` marks holidays / days off, `is_work_day=1` marks shifted working days (e.g. a working Saturday). Default `table=dailytable`.

Both follow the existing `_get_short_data` pattern and are exported from the package `__init__`. Live integration tests added in `tests/test_requests.py` (engines list, dailytable, timetable, engine description), consistent with the existing live-session test style.

Use case: building a trading calendar (holidays / shifted days) was not possible with the existing requests.
